### PR TITLE
Link a fondo pagina al gruppo facebook

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,8 @@ social:
     url: https://bolognatechscene.herokuapp.com/
   - title: github
     url: http://github.com/bolognatechscene
+  - title: facebook
+    url: https://www.facebook.com/BolognaTechScene
 
 # Build settings
 permalink: pretty


### PR DESCRIPTION
Ora che abbiamo una pagina Facebook ho aggiunto un link a fondo pagina.

![image](https://cloud.githubusercontent.com/assets/773288/16561054/13df9f1a-41c5-11e6-9226-63befbbe9ee0.png)

<!---
@huboard:{"order":4.0,"milestone_order":4,"custom_state":""}
-->
